### PR TITLE
do not include lpack for Lua 5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ All the LMDB enums and defines are available through this table as well as the f
 
 
 ## lpack
-As a utility, [LHF's lpack](http://www.tecgraf.puc-rio.br/~lhf/ftp/lua/index.html#lpack) is included in the library.
+As a utility, [LHF's lpack](http://www.tecgraf.puc-rio.br/~lhf/ftp/lua/index.html#lpack) is included in the library for Lua versions lower than 5.3.
 
 ### Usage
 The following is copied verbatim from lpack's original documentation.

--- a/lightningmdb.c
+++ b/lightningmdb.c
@@ -35,7 +35,9 @@ int lua_type_error(lua_State *L,int narg,const char *tname) {
 #define luaL_reg luaL_Reg
 #endif
 
+#if LUA_VERSION_NUM<=502
 #include "lpack.c"
+#endif
 
 #define LIGHTNING "lightningmdb"
 #define ENV "lightningmdb_env"
@@ -629,7 +631,9 @@ static const lua_reg_t globals[] = {
 
 
 int luaopen_lightningmdb(lua_State *L) {
+#if LUA_VERSION_NUM<=502
   luaopen_pack(L);
+#endif
   luaL_newmetatable(L,LIGHTNING);
   lua_set_funcs(L,LIGHTNING,globals);
   setfield_enum(MDB_NOOVERWRITE);


### PR DESCRIPTION
It overrides string.pack() with an incompatible version.